### PR TITLE
Update to 3.6.5: pin python to <3.10

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
 
 build:
   number: 0
+  skip: True  # [py<36]
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
   entry_points:
@@ -17,12 +18,12 @@ build:
 
 requirements:
   host:
-    - python >=3.6,<3.10
+    - python
     - pip
     - setuptools
     - wheel
   run:
-    - python >=3.6,<3.10
+    - python >=3.6
     - click
     - joblib
     - regex >=2021.8.3
@@ -57,6 +58,7 @@ test:
     - nltk.translate
     - nltk.twitter
   requires:
+    - python <3.10
     - pip
     # tqdm and click requires colorama
     - colorama  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.6.3" %}
+{% set version = "3.6.5" %}
 
 package:
   name: nltk
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/n/nltk/nltk-{{ version }}.zip
-  sha256: 5db64a976e88cef0db9200c7f25aeceba8a86efbe09cc824f01a6d3163f7e937
+  sha256: 834d1a8e38496369390be699be9bca4f2a0f2175b50327272b2ec7a98ffda2a0
 
 build:
   number: 0
@@ -17,15 +17,15 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python >=3.6,<3.10
     - pip
     - setuptools
     - wheel
   run:
-    - python >=3.6
+    - python >=3.6,<3.10
     - click
     - joblib
-    - regex
+    - regex >=2021.8.3
     - tqdm
 
 test:


### PR DESCRIPTION
Category:  anaconda | subcategory:  core | pkg_type:  python
Popularity:  938395 downloads -  nltk  3.6.5  Natural Language Toolkit
Version change: bump version number from 3.6.3 to 3.6.5
Requirements from conda-forge: https://github.com/conda-forge/nltk-feedstock/blob/master/recipe/meta.yaml
  license: Apache 2.0
Release date:  Oct 11, 2021
Bug Tracker: new open issues https://github.com/nltk/nltk/issues
Github releases:  https://github.com/nltk/nltk/releases
Upstream License: https://github.com/nltk/nltk/blob/develop/LICENSE.txt
Upstream Changelog: https://github.com/nltk/nltk/blob/develop/ChangeLog
Upstream setup.py: https://github.com/nltk/nltk/blob/3.6.5/setup.py

Actions:
1. Update dependencies: `regex >=2021.8.3`
2. Pin `python>=3.6,<3.10`

Result:
- all-succeeded