### PR TITLE
nltk 3.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,6 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<37]
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,9 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<36]
+  skip: True  # [py<37]
   noarch: python
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - nltk = nltk.cli:cli
 
@@ -23,7 +23,7 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python >=3.6
+    - python >=3.7
     - click
     - joblib
     - regex >=2021.8.3
@@ -58,7 +58,6 @@ test:
     - nltk.translate
     - nltk.twitter
   requires:
-    - python <3.10
     - pip
     # tqdm and click requires colorama
     - colorama  # [win]
@@ -67,9 +66,9 @@ test:
     - nltk -h
 
 about:
-  home: http://nltk.org/
+  home: https://nltk.org/
   license_file: LICENSE.txt
-  license: Apache 2.0
+  license: Apache-2.0
   license_family: Apache
   summary: 'Natural Language Toolkit'
   description: |
@@ -78,7 +77,7 @@ about:
     natural language.
   doc_source_url: https://github.com/nltk/nltk/blob/develop/web/index.rst
   dev_url: https://github.com/nltk/nltk
-  doc_url: http://www.nltk.org/
+  doc_url: https://www.nltk.org/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.6.5" %}
+{% set version = "3.7" %}
 
 package:
   name: nltk
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/n/nltk/nltk-{{ version }}.zip
-  sha256: 834d1a8e38496369390be699be9bca4f2a0f2175b50327272b2ec7a98ffda2a0
+  sha256: d6507d6460cec76d70afea4242a226a7542f85c669177b9c7f562b7cf1b05502
 
 build:
   number: 0


### PR DESCRIPTION
Update nltk to 3.7

Version change: bump version number from 3.6.5 to 3.7
Bug Tracker: new open issues https://github.com/nltk/nltk/issues
Upstream License: https://github.com/nltk/nltk/blob/develop/LICENSE.txt
Upstream Changelog: https://github.com/nltk/nltk/blob/develop/ChangeLog
Upstream setup.py: https://github.com/nltk/nltk/blob/3.7/setup.py

Actions:
1. Skip `py<37`
2. Update `python >=3.7` in `run`
3. Remove `python <3.10` in `test/requires`
4. Fix home and doc urls with HTTPS
5. Fix license name

Result:
- all-succeeded