### PR TITLE
nltk 3.8.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,18 @@
+{% set name = "nltk" %}
 {% set version = "3.7" %}
 
 package:
-  name: nltk
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/n/nltk/nltk-{{ version }}.zip
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.zip
   sha256: d6507d6460cec76d70afea4242a226a7542f85c669177b9c7f562b7cf1b05502
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  skip: True  # [py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - nltk = nltk.cli:cli
 
@@ -22,7 +23,7 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python >=3.7
+    - python
     - click
     - joblib
     - regex >=2021.8.3
@@ -69,7 +70,7 @@ about:
   license_file: LICENSE.txt
   license: Apache-2.0
   license_family: Apache
-  summary: 'Natural Language Toolkit'
+  summary: Natural Language Toolkit
   description: |
     NLTK has been called a wonderful tool for teaching and working in
     computational linguistics using Python and an amazing library to play with

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,7 +66,7 @@ test:
     - nltk -h
 
 about:
-  home: https://nltk.org/
+  home: https://www.nltk.org/
   license_file: LICENSE.txt
   license: Apache-2.0
   license_family: Apache
@@ -75,7 +75,6 @@ about:
     NLTK has been called a wonderful tool for teaching and working in
     computational linguistics using Python and an amazing library to play with
     natural language.
-  doc_source_url: https://github.com/nltk/nltk/blob/develop/web/index.rst
   dev_url: https://github.com/nltk/nltk
   doc_url: https://www.nltk.org/
 


### PR DESCRIPTION
Changelog: https://github.com/nltk/nltk/blob/3.8.1/ChangeLog
License: https://github.com/nltk/nltk/blob/3.8.1/LICENSE.txt
Requirements: https://github.com/nltk/nltk/blob/3.8.1/setup.py

Actions:
1. Remove `noarch`
2. Skip `py<37`
3. Add `--no-build-isolation` to `script`
4. Fix `python` in `host` and `run`
5. Update `home` url
6. Remove `doc_source_url`