### PR TITLE
nltk 3.9.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nltk" %}
-{% set version = "3.9.2" %}
+{% set version = "3.9.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 0f409e9b069ca4177c1903c3e843eef90c7e92992fa4931ae607da6de49e1419
+  sha256: cb5945d6424a98d694c2b9a0264519fab4363711065a46aa0ae7a2195b92e71f
 
 build:
   number: 0


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-12662](https://anaconda.atlassian.net/browse/PKG-12662)
- [Upstream repository](https://github.com/nltk/nltk)

### Explanation of changes:

- Bump version
- Fixes [CVE-2025-14009](https://nvd.nist.gov/vuln/detail/CVE-2025-14009)


[PKG-12662]: https://anaconda.atlassian.net/browse/PKG-12662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ